### PR TITLE
update to 0.7.4 of systemjs-builder (based on another commit to the seed...)

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -155,6 +155,8 @@ var buildTree = function (tree, destination, config) {
     return builder.buildTree(tree.tree, 'dist/' + destination + '.js', {
       sourceMaps: config.sourceMaps,
       minify: config.minify,
+      mangle: config.mangle,
+      config: config.config,
       main: config.main,
       dest: config.dest,
       destJs: config.destJs

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"gulp": "^3.8.10",
 		"gulp-insert": "^0.4.0",
 		"gulp-6to5": "^3.0.0",
-		"systemjs-builder": "^0.7.2",
+		"systemjs-builder": "^0.7.4",
 		"rsvp": "^3.0.16",
 		"node-v8-clone": "^0.6.2"
 	}


### PR DESCRIPTION
not really sure why we don't just pass the whole config object?
