### PR TITLE
Improve test framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 node_modules
 test/output
+test/jspm_packages

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
 language: node_js 
 node_js:
   - '0.10'
-before_install:
-  - 'npm install'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: node_js 
 node_js:
   - '0.10'
+  - '0.11'
+  - '0.12'

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     "bundler"
   ],
   "scripts": {
-    "test": "rm -rf test/output && babel test/fixtures/app --out-dir test/output/app --modules system && mocha --compilers js:babel/register test/**/*.spec.js"
+    "test": "test/run.sh"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,14 +7,14 @@
   "dependencies": {
     "gulp": "^3.8.11",
     "gulp-insert": "^0.4.0",
-    "systemjs-builder": "^0.10.4",
+    "systemjs-builder": "^0.10.6",
     "rsvp": "^3.0.18",
     "node-v8-clone": "^0.6.2"
   },
   "devDependencies": {
-    "babel": "^5.0.7",
-    "babel-runtime": "^5.0.7",
-    "mocha": "^2.2.1"
+    "babel": "^5.1.13",
+    "babel-runtime": "^5.1.13",
+    "mocha": "^2.2.4"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "devDependencies": {
     "babel": "^5.1.13",
     "babel-runtime": "^5.1.13",
+    "jspm": "^0.15.5",
     "mocha": "^2.2.4"
   },
   "repository": {
@@ -27,5 +28,21 @@
   ],
   "scripts": {
     "test": "test/run.sh"
+  },
+  "jspm": {
+    "directories": {
+      "baseURL": "test/output",
+      "lib": "test/fixtures",
+      "packages": "test/jspm_packages"
+    },
+    "configFile": "test/fixtures/system.config.js",
+    "dependencies": {
+      "angular": "github:angular/bower-angular@^1.3.15"
+    },
+    "devDependencies": {
+      "babel": "npm:babel-core@^5.1.13",
+      "babel-runtime": "npm:babel-runtime@^5.1.13",
+      "core-js": "npm:core-js@^0.9.4"
+    }
   }
 }

--- a/test/builder.spec.js
+++ b/test/builder.spec.js
@@ -22,7 +22,7 @@ let config = {
 	routes: routesSrc,
 	bundleThreshold: 2.0,
 	config: 'test/fixtures/system.config.js',
-	sourceMaps: false,
+	sourceMaps: true,
 	minify: false,
 	dest: 'test/output',
 	destJs: 'test/output/app.js'

--- a/test/builder.spec.js
+++ b/test/builder.spec.js
@@ -20,7 +20,7 @@ let config = {
 	baseURL: 'test/output/',
 	main: 'app/app',
 	routes: routesSrc,
-	bundleThreshold: 0.6,
+	bundleThreshold: 2.0,
 	config: 'test/fixtures/system.config.js',
 	sourceMaps: false,
 	minify: false,

--- a/test/fixtures/app/app.js
+++ b/test/fixtures/app/app.js
@@ -1,5 +1,4 @@
 import angular from 'angular';
-import Util from 'app/common/util';
 
 export default class App {
 

--- a/test/fixtures/app/app.js
+++ b/test/fixtures/app/app.js
@@ -1,3 +1,4 @@
+import angular from 'angular';
 import Util from 'app/common/util';
 
 export default class App {

--- a/test/fixtures/app/route1/route1.js
+++ b/test/fixtures/app/route1/route1.js
@@ -1,8 +1,11 @@
+import angular from 'angular';
+
 import App from '../app';
 import Common from '../common/common';
 
 export default class Route1 {
   constructor() {
     console.log('route1');
+    angular.module();
   }
 };

--- a/test/fixtures/app/route1/route1.js
+++ b/test/fixtures/app/route1/route1.js
@@ -1,11 +1,11 @@
 import angular from 'angular';
 
 import App from '../app';
-import Common from '../common/common';
+import Util from '../common/util';
 
 export default class Route1 {
   constructor() {
     console.log('route1');
-    angular.module();
+    angular.module('myModule', []);
   }
 };

--- a/test/fixtures/app/route2/route2.js
+++ b/test/fixtures/app/route2/route2.js
@@ -1,5 +1,5 @@
 import App from '../app';
-import Common from '../common/common';
+import Util from '../common/util';
 
 export default class Route2 {
   constructor() {

--- a/test/fixtures/system.config.js
+++ b/test/fixtures/system.config.js
@@ -1,14 +1,32 @@
 System.config({
-	"baseURL": ".",
-	"transpiler": "babel",
-	"babelOptions": {
-		"optional": [
-			"runtime"
-		]
-	},
-	"paths": {
-		"*": "*.js"
-	},
-	"buildCSS": true,
-	"separateCSS": false
+  "baseURL": ".",
+  "transpiler": "babel",
+  "babelOptions": {
+    "optional": [
+      "runtime"
+    ]
+  },
+  "paths": {
+    "*": "*.js",
+    "github:*": "../jspm_packages/github/*.js",
+    "npm:*": "../jspm_packages/npm/*.js"
+  },
+  "buildCSS": true,
+  "separateCSS": false
 });
+
+System.config({
+  "map": {
+    "angular": "github:angular/bower-angular@1.3.15",
+    "babel": "npm:babel-core@5.1.13",
+    "babel-runtime": "npm:babel-runtime@5.1.13",
+    "core-js": "npm:core-js@0.9.4",
+    "github:jspm/nodelibs-process@0.1.1": {
+      "process": "npm:process@0.10.1"
+    },
+    "npm:core-js@0.9.4": {
+      "process": "github:jspm/nodelibs-process@0.1.1"
+    }
+  }
+});
+

--- a/test/run.sh
+++ b/test/run.sh
@@ -12,4 +12,4 @@ fi
 
 babel test/fixtures/app --out-dir test/output/app --modules system
 
-mocha --compilers js:babel/register test/**/*.spec.js
+mocha --timeout 5000 --compilers js:babel/register test/**/*.spec.js

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ -d "test/output" ]; then
+  rm -rf test/output
+fi
+
+if [ ! -d "test/jspm_packages" ]; then
+  jspm install
+fi
+
+babel test/fixtures/app --out-dir test/output/app --modules system
+
+mocha --compilers js:babel/register test/**/*.spec.js


### PR DESCRIPTION
There is a few main issues here:
- I have to set the `bundleThreshold` to > 1 in order to get bundles to be generated.
  - Even with it > 1, the bundle doesn't seem to be correctly referenced in the files.
- The sourcemaps have absolute urls in them. Probably related to: https://github.com/systemjs/builder/issues/157 (this is so that @crisptrutski will have an easy test)
- I'm not sure we need the absolute path to angular in the output? Instead of `System.register("github:angular/bower-angular@1.3.15")`, can't we just have it say `System.register("angular")`?

At some point when this is pretty stable and working, I'll write some passing tests. I guess mostly I just want to grep some of the output JS code and look for specific things.
