### PR TITLE
fix output directories

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -144,7 +144,7 @@ var buildTrees = function (bundles, config) {
   console.log('building bundles...');
   Object.keys(bundles).forEach(function (bundleName) {
     builderPromises.push(new RSVP.Promise(function (resolve, reject) {
-      buildTree(bundles[bundleName], config.dest + "bundles/" + bundleName + '.js', config).then(function () {
+      buildTree(bundles[bundleName], config.dest + "/bundles/" + bundleName + '.js', config).then(function () {
         resolve();
       }, function (error) {
         console.log(error)
@@ -179,15 +179,18 @@ var buildTrees = function (bundles, config) {
   console.log('building app...');
   Object.keys(appTree).forEach(function (moduleName) {
     builderPromises.push(new RSVP.Promise(function (resolve, reject) {
-      buildTree(appTree[moduleName], moduleName, config).then(function () {
-        if (moduleName === config.main) {
+      var isMainModule = moduleName === config.main;
+      var destination = isMainModule ? config.destJs : moduleName;
+      
+      buildTree(appTree[moduleName], destination, config).then(function () {
+        if (isMainModule) {
           if (config.verboseOutput){
             console.log('embedding bundles config...');
           }
           var bundlesString = "System.config({bundles: " + JSON.stringify(bundlesConfig, null, 4) + "});";
           gulp.src(config.destJs)
             .pipe(insert.prepend(bundlesString))
-            .pipe(gulp.dest(config.dest + "app"));
+            .pipe(gulp.dest(config.dest));
         }
         resolve();
       }, function (error) {


### PR DESCRIPTION
Fixed output so that it will go to (for example) app/app.js and app/bundles/bundle.js instead of appapp/app.js and appbundles/bundle.js. Also fixed to work with directory structures that are different to angular-systemjs-seed.
